### PR TITLE
Add support for fenced code blocks with mermaid syntax

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -24,3 +24,14 @@ form:
         0: Disabled
       validate:
         type: bool
+    fenced_code_blocks:
+      type: toggle
+      label: Fenced Code Blocks
+      help: "Enable support for ```mermaid fenced code blocks in addition to [mermaid]...[/mermaid] tags"
+      highlight: 1
+      default: 1
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool

--- a/mermaid-diagrams.php
+++ b/mermaid-diagrams.php
@@ -52,13 +52,15 @@ class MermaidDiagramsPlugin extends Plugin
 
             $raw = $this->parseInjectMermaid($raw, $match_mermaid);
 
-            $match_mermaid_fenced = function ($matches) {
-                $replace_header = "<div class=\"mermaid\" style=\"text-align:".$this->align."\">";
-                $replace_footer = "</div>";
-                return $replace_header . $matches[1] . $replace_footer;
-            };
+            if ($this->config->get('plugins.mermaid-diagrams.fenced_code_blocks')) {
+                $match_mermaid_fenced = function ($matches) {
+                    $replace_header = "<div class=\"mermaid\" style=\"text-align:".$this->align."\">";
+                    $replace_footer = "</div>";
+                    return $replace_header . $matches[1] . $replace_footer;
+                };
 
-            $raw = $this->parseInjectMermaidFenced($raw, $match_mermaid_fenced);
+                $raw = $this->parseInjectMermaidFenced($raw, $match_mermaid_fenced);
+            }
 
             $page->setRawContent($raw);
         }

--- a/mermaid-diagrams.php
+++ b/mermaid-diagrams.php
@@ -52,6 +52,14 @@ class MermaidDiagramsPlugin extends Plugin
 
             $raw = $this->parseInjectMermaid($raw, $match_mermaid);
 
+            $match_mermaid_fenced = function ($matches) {
+                $replace_header = "<div class=\"mermaid\" style=\"text-align:".$this->align."\">";
+                $replace_footer = "</div>";
+                return $replace_header . $matches[1] . $replace_footer;
+            };
+
+            $raw = $this->parseInjectMermaidFenced($raw, $match_mermaid_fenced);
+
             $page->setRawContent($raw);
         }
     }
@@ -63,6 +71,12 @@ class MermaidDiagramsPlugin extends Plugin
     {
         // Regular Expression for selection
         $regex = '/\[mermaid\]([\s\S]*?)\[\/mermaid\]/';
+        return preg_replace_callback($regex, $function, $content);
+    }
+
+    protected function parseInjectMermaidFenced($content, $function)
+    {
+        $regex = '/```mermaid\s*\n?([\s\S]*?)```/';
         return preg_replace_callback($regex, $function, $content);
     }
 

--- a/mermaid-diagrams.yaml
+++ b/mermaid-diagrams.yaml
@@ -3,6 +3,7 @@
 
 enabled: true	# Plugin activation
 align: center	# Position of diagrams [left, center, right]
+fenced_code_blocks: false	# Support ```mermaid fenced code blocks, default: false for backward compatibility
 
 # Settings of sequence diagrams
 # ****************


### PR DESCRIPTION
# Add support for fenced code blocks with mermaid syntax

This PR adds support for rendering Mermaid diagrams using fenced code blocks with the `mermaid` language identifier. Users can now create diagrams using either the existing custom syntax or the more standard markdown fenced code block approach:

```mermaid
graph TD
    A[Start] --> B[End]
```

The implementation:
- Adds a new regex pattern to match fenced code blocks with the `mermaid` language identifier
- Creates a helper method `parseInjectMermaidFenced()` to process these blocks
- Maintains the same styling and alignment options as the existing implementation
- adds a toggle to enable or disable this feature. Defaults to false for backwards-compatibility.